### PR TITLE
Add netcore support to OxyPlot.GtkSharp3

### DIFF
--- a/Source/Examples/GtkSharp3/ExampleBrowser/ExampleBrowserGtk3.csproj
+++ b/Source/Examples/GtkSharp3/ExampleBrowser/ExampleBrowserGtk3.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFrameworks>net461;netcoreapp2.1</TargetFrameworks>
     <RootNamespace>ExampleBrowser</RootNamespace>
     <OutputType>WinExe</OutputType>
   </PropertyGroup>
@@ -9,11 +9,9 @@
     <ProjectReference Include="..\..\..\OxyPlot.GtkSharp3\OxyPlot.GtkSharp3.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="gtk-sharp-3" Version="3.22.6.4" />
-    <PackageReference Include="OxyPlot.Core" Version="2.0.0-unstable1013" />
     <PackageReference Include="OxyPlot.ExampleLibrary" Version="2.0.0-unstable0956" />
+    <PackageReference Include="GtkSharp" Version="3.22.25.*" />
   </ItemGroup>
-  <ItemGroup />
   <ItemGroup>
     <None Include="App.config" />
   </ItemGroup>

--- a/Source/Examples/GtkSharp3/GtkSharpDemo/GtkSharp3Demo.csproj
+++ b/Source/Examples/GtkSharp3/GtkSharpDemo/GtkSharp3Demo.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFrameworks>net461;netcoreapp2.1</TargetFrameworks>
     <RootNamespace>GtkSharpDemo</RootNamespace>
     <OutputType>WinExe</OutputType>
   </PropertyGroup>
@@ -9,8 +9,7 @@
     <ProjectReference Include="..\..\..\OxyPlot.GtkSharp3\OxyPlot.GtkSharp3.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="gtk-sharp-3" Version="3.22.6.4" />
-    <PackageReference Include="OxyPlot.Core" Version="2.0.0-unstable1013" />
+    <PackageReference Include="GtkSharp" Version="3.22.25.*" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />

--- a/Source/OxyPlot.GtkSharp.Shared/PlotView.cs
+++ b/Source/OxyPlot.GtkSharp.Shared/PlotView.cs
@@ -368,9 +368,14 @@ namespace OxyPlot.GtkSharp
         /// </summary>
         /// <param name="e">An instance that contains the event data.</param>
         /// <returns><c>true</c> if the event was handled.</returns>
+        /// <remarks>
+        /// The way that scroll direction is determined is different between
+        /// gtk2 and gtk3, hence the need for version-specific imlementations of
+        /// GetMouseWheelEventArgs(Gdk.EventScroll) function.
+        /// </remarks>
         protected override bool OnScrollEvent(EventScroll e)
         {
-            return this.ActualController.HandleMouseWheel(this, e.ToMouseWheelEventArgs());
+            return this.ActualController.HandleMouseWheel(this, GetMouseWheelEventArgs(e));
         }
 
         /// <summary>

--- a/Source/OxyPlot.GtkSharp.Shared/Utilities/ConverterExtensions.cs
+++ b/Source/OxyPlot.GtkSharp.Shared/Utilities/ConverterExtensions.cs
@@ -181,9 +181,18 @@ namespace OxyPlot.GtkSharp
         /// <returns>Mouse event arguments.</returns>
         public static OxyMouseWheelEventArgs ToMouseWheelEventArgs(this EventScroll e)
         {
+            int delta;
+#if NETFRAMEWORK
+            delta = e.Direction == ScrollDirection.Down ? -120 : 120;
+#else
+            if (e.Direction == ScrollDirection.Smooth)
+                delta = e.DeltaY < 0 ? 120 : -120;
+            else
+                delta = e.Direction == ScrollDirection.Down ? -120 : 120; // untested
+#endif
             return new OxyMouseWheelEventArgs
             {
-                Delta = e.Direction == ScrollDirection.Down ? -120 : 120,
+                Delta = delta,
                 Position = new ScreenPoint(e.X, e.Y),
                 ModifierKeys = GetModifiers(e.State)
             };

--- a/Source/OxyPlot.GtkSharp.Shared/Utilities/ConverterExtensions.cs
+++ b/Source/OxyPlot.GtkSharp.Shared/Utilities/ConverterExtensions.cs
@@ -175,26 +175,6 @@ namespace OxyPlot.GtkSharp
         }
 
         /// <summary>
-        /// Creates the mouse wheel event arguments.
-        /// </summary>
-        /// <param name="e">The scroll event args.</param>
-        /// <returns>Mouse event arguments.</returns>
-        public static OxyMouseWheelEventArgs ToMouseWheelEventArgs(this EventScroll e)
-        {
-            int delta;
-            if (e.Direction == ScrollDirection.Smooth)
-                delta = e.DeltaY < 0 ? 120 : -120;
-            else
-                delta = e.Direction == ScrollDirection.Down ? -120 : 120;
-            return new OxyMouseWheelEventArgs
-            {
-                Delta = delta,
-                Position = new ScreenPoint(e.X, e.Y),
-                ModifierKeys = GetModifiers(e.State)
-            };
-        }
-
-        /// <summary>
         /// Creates the key event arguments.
         /// </summary>
         /// <param name="e">The key event args.</param>
@@ -439,7 +419,7 @@ namespace OxyPlot.GtkSharp
         /// </summary>
         /// <param name="state">The state.</param>
         /// <returns>The modifier keys.</returns>
-        private static OxyModifierKeys GetModifiers(ModifierType state)
+        public static OxyModifierKeys GetModifiers(ModifierType state)
         {
             var result = OxyModifierKeys.None;
 

--- a/Source/OxyPlot.GtkSharp.Shared/Utilities/ConverterExtensions.cs
+++ b/Source/OxyPlot.GtkSharp.Shared/Utilities/ConverterExtensions.cs
@@ -185,7 +185,7 @@ namespace OxyPlot.GtkSharp
             if (e.Direction == ScrollDirection.Smooth)
                 delta = e.DeltaY < 0 ? 120 : -120;
             else
-                delta = e.Direction == ScrollDirection.Down ? -120 : 120; // untested
+                delta = e.Direction == ScrollDirection.Down ? -120 : 120;
             return new OxyMouseWheelEventArgs
             {
                 Delta = delta,

--- a/Source/OxyPlot.GtkSharp.Shared/Utilities/ConverterExtensions.cs
+++ b/Source/OxyPlot.GtkSharp.Shared/Utilities/ConverterExtensions.cs
@@ -182,14 +182,10 @@ namespace OxyPlot.GtkSharp
         public static OxyMouseWheelEventArgs ToMouseWheelEventArgs(this EventScroll e)
         {
             int delta;
-#if NETFRAMEWORK
-            delta = e.Direction == ScrollDirection.Down ? -120 : 120;
-#else
             if (e.Direction == ScrollDirection.Smooth)
                 delta = e.DeltaY < 0 ? 120 : -120;
             else
                 delta = e.Direction == ScrollDirection.Down ? -120 : 120; // untested
-#endif
             return new OxyMouseWheelEventArgs
             {
                 Delta = delta,

--- a/Source/OxyPlot.GtkSharp.sln
+++ b/Source/OxyPlot.GtkSharp.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27004.2009
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30204.135
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OxyPlot.GtkSharp", "OxyPlot.GtkSharp\OxyPlot.GtkSharp.csproj", "{89D008D7-AD33-4AB6-B61A-064C48DA6699}"
 EndProject
@@ -37,9 +37,15 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
+		Examples\GtkSharp.Shared\GtkSharpDemo\GtkSharpDemo.Shared.projitems*{04c4f5cf-4b8a-4d27-9562-462581c1d323}*SharedItemsImports = 5
 		Examples\GtkSharp.Shared\ExampleBrowser\ExampleBrowser.Shared.projitems*{064ee52b-483c-4e96-a9de-2a2d293ea741}*SharedItemsImports = 13
 		Examples\GtkSharp.Shared\GtkSharpDemo\GtkSharpDemo.Shared.projitems*{08c8bdff-cf2a-484d-8051-289538774d35}*SharedItemsImports = 13
+		Examples\GtkSharp.Shared\GtkSharpDemo\GtkSharpDemo.Shared.projitems*{480a7e68-5f4d-48c8-a8bd-e2dc1ba362e6}*SharedItemsImports = 5
+		Examples\GtkSharp.Shared\ExampleBrowser\ExampleBrowser.Shared.projitems*{7cecf810-9b40-46a9-9b56-5a719cfdcad0}*SharedItemsImports = 5
+		OxyPlot.GtkSharp.Shared\OxyPlot.GtkSharp.Shared.projitems*{89d008d7-ad33-4ab6-b61a-064c48da6699}*SharedItemsImports = 5
+		OxyPlot.GtkSharp.Shared\OxyPlot.GtkSharp.Shared.projitems*{8b2dc377-4689-4252-aa08-3acd06a045f3}*SharedItemsImports = 5
 		OxyPlot.GtkSharp.Shared\OxyPlot.GtkSharp.Shared.projitems*{ae281d72-34a8-4b84-aa7c-e1bace70f0c0}*SharedItemsImports = 13
+		Examples\GtkSharp.Shared\ExampleBrowser\ExampleBrowser.Shared.projitems*{ba5651be-8b77-4107-8df7-ffb73c850e18}*SharedItemsImports = 5
 	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/Source/OxyPlot.GtkSharp/PlotViewGtk2.cs
+++ b/Source/OxyPlot.GtkSharp/PlotViewGtk2.cs
@@ -52,6 +52,21 @@ namespace OxyPlot.GtkSharp
 
             return base.OnExposeEvent(evnt);
         }
+
+        /// <summary>
+        /// Creates the mouse wheel event arguments.
+        /// </summary>
+        /// <param name="e">The scroll event args.</param>
+        /// <returns>Mouse event arguments.</returns>
+        private static OxyMouseWheelEventArgs GetMouseWheelEventArgs(Gdk.EventScroll e)
+        {
+            return new OxyMouseWheelEventArgs
+            {
+                Delta = e.Direction == Gdk.ScrollDirection.Down ? -120 : 120,
+                Position = new ScreenPoint(e.X, e.Y),
+                ModifierKeys = ConverterExtensions.GetModifiers(e.State)
+            };
+        }
     }
 }
 

--- a/Source/OxyPlot.GtkSharp3/OxyPlot.GtkSharp3.csproj
+++ b/Source/OxyPlot.GtkSharp3/OxyPlot.GtkSharp3.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>OxyPlot.GtkSharp</RootNamespace>
     <PackageId>OxyPlot.GtkSharp3</PackageId>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
@@ -17,7 +17,7 @@
   </PropertyGroup>
   <Import Project="..\OxyPlot.GtkSharp.Shared\OxyPlot.GtkSharp.Shared.projitems" Label="Shared" />
   <ItemGroup>
-    <PackageReference Include="gtk-sharp-3" Version="3.22.6.4" />
+    <PackageReference Include="GtkSharp" Version="3.22.25.*" />
     <PackageReference Include="OxyPlot.Core" Version="2.0.0-unstable1013" />
   </ItemGroup>
 </Project>

--- a/Source/OxyPlot.GtkSharp3/PlotViewGtk3.cs
+++ b/Source/OxyPlot.GtkSharp3/PlotViewGtk3.cs
@@ -44,6 +44,26 @@ namespace OxyPlot.GtkSharp
             this.DrawPlot (cr);
             return base.OnDrawn (cr);
         }
+
+        /// <summary>
+        /// Creates the mouse wheel event arguments.
+        /// </summary>
+        /// <param name="e">The scroll event args.</param>
+        /// <returns>Mouse event arguments.</returns>
+        private static OxyMouseWheelEventArgs GetMouseWheelEventArgs(Gdk.EventScroll e)
+        {
+            int delta;
+            if (e.Direction == Gdk.ScrollDirection.Smooth)
+                delta = e.DeltaY < 0 ? 120 : -120;
+            else
+                delta = e.Direction == Gdk.ScrollDirection.Down ? -120 : 120;
+            return new OxyMouseWheelEventArgs
+            {
+                Delta = delta,
+                Position = new ScreenPoint(e.X, e.Y),
+                ModifierKeys = ConverterExtensions.GetModifiers(e.State)
+            };
+        }
     }
 }
 


### PR DESCRIPTION
Fixes #9

- using https://github.com/GtkSharp/GtkSharp for netcore support
- Had to tweak mouse scroll event handler, as the api is a bit different between gtk2/gtk3
- tested ExampleBrowserGtk3 under net461 and netcoreapp2.1, on windows and Linux, seems to work ok