### PR TITLE
memory leak fixed(?)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,4 @@ All notable changes to this project will be documented in this file.
 - Depend on OxyPlot.Core 1.0.0
 - Build OxyPlot.GtkSharp with GtkSharp 2.12.45
 - Build OxyPlot.GtkSharp3 with GtkSharp 2.99.3
+- Mitigate memory issue with Pango.Layout #11

--- a/Source/OxyPlot.GtkSharp.Shared/GraphicsRenderContext.cs
+++ b/Source/OxyPlot.GtkSharp.Shared/GraphicsRenderContext.cs
@@ -40,6 +40,11 @@ namespace OxyPlot.GtkSharp
         private Cairo.Context g;
 
         /// <summary>
+        /// The text layout context
+        /// </summary>
+        private Pango.Context c;
+
+        /// <summary>
         /// Sets the graphics target.
         /// </summary>
         /// <param name="graphics">The graphics surface.</param>
@@ -47,6 +52,7 @@ namespace OxyPlot.GtkSharp
         {
             this.g = graphics;
             this.g.Antialias = Antialias.Subpixel; // TODO  .TextRenderingHint = TextRenderingHint.AntiAliasGridFit;
+            this.c = Pango.CairoHelper.CreateContext(this.g);
         }
 
         /// <summary>
@@ -258,7 +264,7 @@ namespace OxyPlot.GtkSharp
             VerticalAlignment valign,
             OxySize? maxSize)
         {
-            Pango.Layout layout = Pango.CairoHelper.CreateLayout(this.g);
+            Pango.Layout layout = new Layout(this.c);
             Pango.FontDescription font = new Pango.FontDescription();
             font.Family = fontFamily;
             font.Weight = (fontWeight >= 700) ? Pango.Weight.Bold : Pango.Weight.Normal;
@@ -330,7 +336,7 @@ namespace OxyPlot.GtkSharp
                 return OxySize.Empty;
             }
             this.g.Save();
-            Pango.Layout layout = Pango.CairoHelper.CreateLayout(this.g);
+            Pango.Layout layout = new Layout(this.c);
             Pango.FontDescription font = new Pango.FontDescription();
             font.Family = fontFamily;
             font.Weight = (fontWeight >= 700) ? Pango.Weight.Bold : Pango.Weight.Normal;


### PR DESCRIPTION
Fixes #11

- don't use `Pango.CreateLayout` per `Draw/MeasureText` call
- I'm not a GTK expert, just figured out that this constellation doesn't seem to leak