### PR TITLE
Fix application freeze under X11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,4 @@ All notable changes to this project will be documented in this file.
 - Depend on OxyPlot.Core 1.0.0
 - Build OxyPlot.GtkSharp with GtkSharp 2.12.45
 - Build OxyPlot.GtkSharp3 with GtkSharp 2.99.3
+- Fix application freeze on Linux/X11 when viewing "show tracker without clicking" example (#13)

--- a/Source/OxyPlot.GtkSharp.Shared/PlotView.cs
+++ b/Source/OxyPlot.GtkSharp.Shared/PlotView.cs
@@ -380,6 +380,12 @@ namespace OxyPlot.GtkSharp
         /// <returns><c>true</c> if the event was handled.</returns>
         protected override bool OnEnterNotifyEvent(EventCrossing e)
         {
+            // If mouse has entered from an inferior window (ie the tracker label),
+            // further propagation of the event could be dangerous; e.g. if it results in
+            // the label being moved, it will cause further LeaveNotify and MotionNotify
+            // events being fired under X11.
+            if (e.Detail == NotifyType.Inferior)
+                return base.OnEnterNotifyEvent(e);
             return this.ActualController.HandleMouseEnter(this, e.ToMouseEventArgs());
         }
 
@@ -390,6 +396,12 @@ namespace OxyPlot.GtkSharp
         /// <returns><c>true</c> if the event was handled.</returns>
         protected override bool OnLeaveNotifyEvent(EventCrossing e)
         {
+            // If mouse has left via an inferior window (ie the tracker label),
+            // further propagation of the event could be dangerous; e.g. if it results in
+            // the label being moved, it will cause further LeaveNotify and MotionNotify
+            // events being fired under X11.
+            if (e.Detail == NotifyType.Inferior)
+                return base.OnLeaveNotifyEvent(e);
             return this.ActualController.HandleMouseLeave(this, e.ToMouseEventArgs());
         }
 


### PR DESCRIPTION
This fixes #13

See my comment on #13, and the commit message for details. Basically, propagating the mouse enter/leave events when the mouse has entered/left the plot area via the tracker label is dangerous and can result in an infinite series of enter/leave events to occur.