### PR TITLE
Compat fixes to allow running oxyplot-gtksharp with oxyplot 2.1.0(-Preview1)

### DIFF
--- a/Source/Examples/GtkSharp/ExampleBrowser/ExampleBrowser.csproj
+++ b/Source/Examples/GtkSharp/ExampleBrowser/ExampleBrowser.csproj
@@ -8,7 +8,7 @@
     <ProjectReference Include="..\..\..\OxyPlot.GtkSharp\OxyPlot.GtkSharp.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="OxyPlot.Core" Version="2.0.0-unstable1013" />
+    <PackageReference Include="OxyPlot.Core" Version="2.1.0-Preview1" />
     <PackageReference Include="OxyPlot.ExampleLibrary" Version="2.0.0-unstable0956" />
   </ItemGroup>
   <ItemGroup>

--- a/Source/Examples/GtkSharp/GtkSharpDemo/GtkSharpDemo.csproj
+++ b/Source/Examples/GtkSharp/GtkSharpDemo/GtkSharpDemo.csproj
@@ -8,7 +8,7 @@
     <ProjectReference Include="..\..\..\OxyPlot.GtkSharp\OxyPlot.GtkSharp.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="OxyPlot.Core" Version="2.0.0-unstable1013" />
+    <PackageReference Include="OxyPlot.Core" Version="2.1.0-Preview1" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="atk-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f, processorArchitecture=MSIL">

--- a/Source/OxyPlot.GtkSharp.Shared/PlotView.cs
+++ b/Source/OxyPlot.GtkSharp.Shared/PlotView.cs
@@ -439,21 +439,22 @@ namespace OxyPlot.GtkSharp
 
                 lock (this.renderingLock)
                 {
+                    EdgeRenderingMode edgeRenderingMode = EdgeRenderingMode.Automatic.GetActual(EdgeRenderingMode.Adaptive);
                     this.renderContext.SetGraphicsTarget(cr);
                     if (this.model != null)
                     {
+                        OxyRect rect = new OxyRect(0, 0, Allocation.Width, Allocation.Height);
                         if (!this.model.Background.IsUndefined())
                         {
-                            OxyRect rect = new OxyRect(0, 0, Allocation.Width, Allocation.Height);
-                            this.renderContext.DrawRectangle(rect, this.model.Background, OxyColors.Undefined, 0);
+                            this.renderContext.DrawRectangle(rect, this.model.Background, OxyColors.Undefined, 0, edgeRenderingMode);
                         }
 
-                        ((IPlotModel)this.model).Render(this.renderContext, Allocation.Width, Allocation.Height);
+                        ((IPlotModel)this.model).Render(this.renderContext, rect);
                     }
 
                     if (this.zoomRectangle.HasValue)
                     {
-                        this.renderContext.DrawRectangle(this.zoomRectangle.Value, OxyColor.FromArgb(0x40, 0xFF, 0xFF, 0x00), OxyColors.Transparent, 1.0);
+                        this.renderContext.DrawRectangle(this.zoomRectangle.Value, OxyColor.FromArgb(0x40, 0xFF, 0xFF, 0x00), OxyColors.Transparent, 1.0, edgeRenderingMode);
                     }
                 }
             }

--- a/Source/OxyPlot.GtkSharp.Shared/PngExporter.cs
+++ b/Source/OxyPlot.GtkSharp.Shared/PngExporter.cs
@@ -65,7 +65,8 @@ namespace OxyPlot.GtkSharp
                     var rc = new GraphicsRenderContext { RendersToScreen = false };
                     rc.SetGraphicsTarget(g);
                     model.Update(true);
-                    model.Render(rc, width, height);
+                    OxyRect rect = new OxyRect(0, 0, width, height);
+                    model.Render(rc, rect);
                     bm.WriteToPng(fileName);
                 }
             }
@@ -98,7 +99,7 @@ namespace OxyPlot.GtkSharp
                     var rc = new GraphicsRenderContext { RendersToScreen = false };
                     rc.SetGraphicsTarget(g);
                     model.Update(true);
-                    model.Render(rc, this.Width, this.Height);
+                    model.Render(rc, new OxyRect(0, 0, Width, Height));
 
                     // write to a temporary file
                     var tmp = System.IO.Path.Combine(System.IO.Path.GetTempPath(), Guid.NewGuid() + ".png");

--- a/Source/OxyPlot.GtkSharp/OxyPlot.GtkSharp.csproj
+++ b/Source/OxyPlot.GtkSharp/OxyPlot.GtkSharp.csproj
@@ -16,7 +16,7 @@
   </PropertyGroup>
   <Import Project="..\OxyPlot.GtkSharp.Shared\OxyPlot.GtkSharp.Shared.projitems" Label="Shared" />
   <ItemGroup>
-    <PackageReference Include="OxyPlot.Core" Version="2.0.0-unstable1013" />
+    <PackageReference Include="OxyPlot.Core" Version="2.1.0-Preview1" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Mono.Cairo">

--- a/Source/OxyPlot.GtkSharp3/OxyPlot.GtkSharp3.csproj
+++ b/Source/OxyPlot.GtkSharp3/OxyPlot.GtkSharp3.csproj
@@ -19,6 +19,6 @@
   <Import Project="..\OxyPlot.GtkSharp.Shared\OxyPlot.GtkSharp.Shared.projitems" Label="Shared" />
   <ItemGroup>
     <PackageReference Include="gtk-sharp-3" Version="3.22.6.4" />
-    <PackageReference Include="OxyPlot.Core" Version="2.0.0-unstable1013" />
+    <PackageReference Include="OxyPlot.Core" Version="2.1.0-Preview1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
### Checklist

- [ ] I have included examples or tests
- [ ] I have updated the change log
- [ ] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Minor refactoring to account for upstream changes in oxyplot 2.1.0-Preview1, primarily related to the decision-making with regards to anti-aliasing

I haven't done much manual testing yet - although I will likely do so in the coming weeks. I've only verified that I'm able to view some basic plots. I haven't tested the changes to clipping at all yet (is there an example somewhere which demos this feature?)

@oxyplot/admins
